### PR TITLE
Kleine hotfix voor alle repo's

### DIFF
--- a/DAL/repos/IdeationQuestionsRepository.cs
+++ b/DAL/repos/IdeationQuestionsRepository.cs
@@ -253,7 +253,8 @@ namespace DAL.repos
         public void Update(IdeationQuestion obj)
         {
             IdeationQuestionsDTO newIdeationQuestion = ConvertToDTO(obj);
-            IdeationQuestionsDTO foundIdeationQuestion = ConvertToDTO(Read(obj.Id, false));
+            IdeationQuestion found = Read(obj.Id, false);
+            IdeationQuestionsDTO foundIdeationQuestion = ConvertToDTO(found);
             foundIdeationQuestion = newIdeationQuestion;
 
             ctx.SaveChanges();
@@ -273,11 +274,11 @@ namespace DAL.repos
 
         public IEnumerable<IdeationQuestion> ReadAll()
         {
-            IEnumerable<IdeationQuestion> myQuery = new List<IdeationQuestion>();
+            List<IdeationQuestion> myQuery = new List<IdeationQuestion>();
 
             foreach (IdeationQuestionsDTO DTO in ctx.IdeationQuestions)
             {
-                myQuery.Append(ConvertToDomain(DTO));
+                myQuery.Add(ConvertToDomain(DTO));
             }
 
             return myQuery;
@@ -366,27 +367,33 @@ namespace DAL.repos
         public void Update(Idea obj)
         {
             IdeasDTO newIdea = ConvertToDTO(obj);
-            IdeasDTO foundIdea = ConvertToDTO(ReadIdea(obj.Id, false));
+            Idea found = ReadIdea(obj.Id, false);
+            IdeasDTO foundIdea = ConvertToDTO(found);
             foundIdea = newIdea;
 
             IdeaFieldsDTO newTextField = ConvertToDTO(obj.Field);
-            IdeaFieldsDTO foundTextField = ConvertToDTO(ReadAllFields().ToList().First(f => f.Id == obj.Field.Id));
+            Field foundText = ReadAllFields().ToList().First(f => f.Id == obj.Field.Id);
+            IdeaFieldsDTO foundTextField = ConvertToDTO(foundText);
             newTextField = foundTextField;
 
             IdeaFieldsDTO newCField = ConvertToDTO(obj.Cfield);
-            IdeaFieldsDTO foundCField = ConvertToDTO(ReadAllFields().ToList().First(f => f.Id == obj.Cfield.Id));
+            ClosedField foundClosed = (ClosedField) ReadAllFields().ToList().First(f => f.Id == obj.Cfield.Id);
+            IdeaFieldsDTO foundCField = ConvertToDTO(foundClosed);
             newCField = foundCField;
 
             IdeaFieldsDTO newMField = ConvertToDTO(obj.Mfield);
-            IdeaFieldsDTO foundMField = ConvertToDTO(ReadAllFields().ToList().First(f => f.Id == obj.Mfield.Id));
+            MapField foundMap = (MapField) ReadAllFields().ToList().First(f => f.Id == obj.Mfield.Id);
+            IdeaFieldsDTO foundMField = ConvertToDTO(foundMap);
             newMField = foundMField;
 
             IdeaFieldsDTO newIField = ConvertToDTO(obj.Ifield);
-            IdeaFieldsDTO foundIField = ConvertToDTO(ReadAllFields().ToList().First(f => f.Id == obj.Ifield.Id));
+            ImageField foundImage = (ImageField) ReadAllFields().ToList().First(f => f.Id == obj.Ifield.Id);
+            IdeaFieldsDTO foundIField = ConvertToDTO(foundImage);
             newIField = foundIField;
 
             IdeaFieldsDTO newVField = ConvertToDTO(obj.Vfield);
-            IdeaFieldsDTO foundVField = ConvertToDTO(ReadAllFields().ToList().First(f => f.Id == obj.Vfield.Id));
+            VideoField foundVideo = (VideoField) ReadAllFields().ToList().First(f => f.Id == obj.Vfield.Id);
+            IdeaFieldsDTO foundVField = ConvertToDTO(foundVideo);
             newVField = foundVField;
 
             ctx.SaveChanges();
@@ -436,29 +443,29 @@ namespace DAL.repos
 
         public IEnumerable<Field> ReadAllFields()
         {
-            IEnumerable<Field> myQuery = new List<Field>();
+            List<Field> myQuery = new List<Field>();
 
             foreach (IdeaFieldsDTO DTO in ctx.IdeaFields)
             {
                 if (DTO.FieldText != null)
                 {
-                    myQuery.Append(ConvertFieldToDomain(DTO));
+                    myQuery.Add(ConvertFieldToDomain(DTO));
                 }
                 else if (DTO.FieldStrings != null)
                 {
-                    myQuery.Append(ConvertClosedFieldToDomain(DTO));
+                    myQuery.Add(ConvertClosedFieldToDomain(DTO));
                 }
                 else if (DTO.LocationX > 0)
                 {
-                    myQuery.Append(ConvertMapFieldToDomain(DTO));
+                    myQuery.Add(ConvertMapFieldToDomain(DTO));
                 }
                 else if (DTO.UploadedImage != null)
                 {
-                    myQuery.Append(ConvertImageFieldToDomain(DTO));
+                    myQuery.Add(ConvertImageFieldToDomain(DTO));
                 }
                 else if (DTO.UploadedMedia != null)
                 {
-                    myQuery.Append(ConvertVideoFieldToDomain(DTO));
+                    myQuery.Add(ConvertVideoFieldToDomain(DTO));
                 }
             }
 

--- a/DAL/repos/IdeationRepository.cs
+++ b/DAL/repos/IdeationRepository.cs
@@ -147,11 +147,13 @@ namespace DAL
         public void Update(Ideation obj)
         {
             IdeationsDTO newIdeation = ConvertToDTO(obj);
-            IdeationsDTO foundIdeation = ConvertToDTO(Read(obj.Id, false));
+            Ideation found = Read(obj.Id, false);
+            IdeationsDTO foundIdeation = ConvertToDTO(found);
             foundIdeation = newIdeation;
 
             ModulesDTO newModule = GrabModuleInformationDTO(obj);
-            ModulesDTO foundModule = GrabModuleInformationDTO(ReadWithModule(obj.Id));
+            Ideation foundWModule = ReadWithModule(obj.Id);
+            ModulesDTO foundModule = GrabModuleInformationDTO(foundWModule);
             foundModule = newModule;
 
             ctx.SaveChanges();
@@ -159,18 +161,21 @@ namespace DAL
 
         public void Delete(int id)
         {
-            ctx.Ideations.Remove(ConvertToDTO(Read(id, false)));
-            ctx.Modules.Remove(GrabModuleInformationDTO(Read(id, false)));
+            Ideation toDelete = Read(id, false);
+            ctx.Ideations.Remove(ConvertToDTO(toDelete));
+            Ideation toDeleteModule = Read(id, false);
+            ctx.Modules.Remove(GrabModuleInformationDTO(toDeleteModule));
             ctx.SaveChanges();
         }
         
         public IEnumerable<Ideation> ReadAll()
         {
-            IEnumerable<Ideation> myQuery = new List<Ideation>();
+            List<Ideation> myQuery = new List<Ideation>();
 
             foreach (IdeationsDTO DTO in ctx.Ideations)
             {
-                myQuery.Append(ReadWithModule(DTO.ModuleID));
+                Ideation toAdd = ReadWithModule(DTO.ModuleID);
+                myQuery.Add(toAdd);
             }
 
             return myQuery;
@@ -221,7 +226,8 @@ namespace DAL
         #region
         public string CreateTag(string obj, int moduleID)
         {
-            ModulesDTO module = GrabModuleInformationDTO(Read(moduleID, false));
+            Ideation ideationWTags = Read(moduleID, false);
+            ModulesDTO module = GrabModuleInformationDTO(ideationWTags);
             module.Tags += "," + obj;
             ctx.SaveChanges();
 
@@ -231,7 +237,8 @@ namespace DAL
         public void DeleteTag(int moduleID, int tagID)
         {
             List<String> keptTags = new List<string>();
-            ModulesDTO module = GrabModuleInformationDTO(Read(moduleID, false));
+            Ideation ideationWTags = Read(moduleID, false);
+            ModulesDTO module = GrabModuleInformationDTO(ideationWTags);
             keptTags = ExtensionMethods.StringToList(module.Tags);
             keptTags.RemoveAt(tagID - 1);
             module.Tags = ExtensionMethods.ListToString(keptTags);

--- a/DAL/repos/IdeationVoteRepository.cs
+++ b/DAL/repos/IdeationVoteRepository.cs
@@ -114,24 +114,26 @@ namespace DAL
         public void Update(Vote obj)
         {
             VotesDTO newVote = ConvertToDTO(obj);
-            VotesDTO foundVote = ConvertToDTO(Read(obj.Id, false));
+            Vote found = Read(obj.Id, false);
+            VotesDTO foundVote = ConvertToDTO(found);
             foundVote = newVote;
             ctx.SaveChanges();
         }
         
         public void Delete(int id)
         {
-            ctx.Votes.Remove(ConvertToDTO(Read(id, false)));
+            Vote toDelete = Read(id, false);
+            ctx.Votes.Remove(ConvertToDTO(toDelete));
             ctx.SaveChanges();
         }
         
         public IEnumerable<Vote> ReadAll()
         {
-            IEnumerable<Vote> myQuery = new List<Vote>();
+            List<Vote> myQuery = new List<Vote>();
 
             foreach (VotesDTO DTO in ctx.Votes)
             {
-                myQuery.Append(ConvertToDomain(DTO));
+                myQuery.Add(ConvertToDomain(DTO));
             }
 
             return myQuery;
@@ -187,24 +189,26 @@ namespace DAL
         public void Update(IOT_Device obj)
         {
             DevicesDTO newDevice = ConvertToDTO(obj);
-            DevicesDTO foundDevice = ConvertToDTO(ReadDevice(obj.Id, false));
+            IOT_Device found = ReadDevice(obj.Id, false);
+            DevicesDTO foundDevice = ConvertToDTO(found);
             foundDevice = newDevice;
             ctx.SaveChanges();
         }
 
         public void DeleteDevice(int id)
         {
-            ctx.Devices.Remove(ConvertToDTO(ReadDevice(id, false)));
+            IOT_Device toDelete = ReadDevice(id, false);
+            ctx.Devices.Remove(ConvertToDTO(toDelete));
             ctx.SaveChanges();
         }
 
         public IEnumerable<IOT_Device> ReadAllDevices()
         {
-            IEnumerable<IOT_Device> myQuery = new List<IOT_Device>();
+            List<IOT_Device> myQuery = new List<IOT_Device>();
 
             foreach (DevicesDTO DTO in ctx.Devices)
             {
-                myQuery.Append(ConvertToDomain(DTO));
+                myQuery.Add(ConvertToDomain(DTO));
             }
 
             return myQuery;

--- a/DAL/repos/PlatformRepository.cs
+++ b/DAL/repos/PlatformRepository.cs
@@ -91,24 +91,26 @@ namespace DAL
         public void Update(Platform obj)
         {
             PlatformsDTO newPlatform = ConvertToDTO(obj);
-            PlatformsDTO foundPlatform = ConvertToDTO(Read(obj.Id, false));
+            Platform found = Read(obj.Id, false);
+            PlatformsDTO foundPlatform = ConvertToDTO(found);
             foundPlatform = newPlatform;
             ctx.SaveChanges();
         }
 
         public void Delete(int id)
         {
-            ctx.Platforms.Remove(ConvertToDTO(Read(id, false)));
+            Platform toDelete = Read(id, false);
+            ctx.Platforms.Remove(ConvertToDTO(toDelete));
             ctx.SaveChanges();
         }
 
         public IEnumerable<Platform> ReadAll()
         {
-            IEnumerable<Platform> myQuery = new List<Platform>();
+            List<Platform> myQuery = new List<Platform>();
 
             foreach (PlatformsDTO DTO in ctx.Platforms)
             {
-                myQuery.Append(ConvertToDomain(DTO));
+                myQuery.Add(ConvertToDomain(DTO));
             }
 
             return myQuery;

--- a/DAL/repos/ProjectRepository.cs
+++ b/DAL/repos/ProjectRepository.cs
@@ -152,24 +152,26 @@ namespace DAL
         public void Update(Project obj)
         {
             ProjectsDTO newProj = ConvertToDTO(obj);
-            ProjectsDTO foundProj = ConvertToDTO(Read(newProj.ProjectID, false));
+            Project found = Read(newProj.ProjectID, false);
+            ProjectsDTO foundProj = ConvertToDTO(found);
             foundProj = newProj;
             ctx.SaveChanges();
         }
 
         public void Delete(int id)
         {
-            ctx.Projects.Remove(ConvertToDTO(Read(id, false)));
+            Project toDelete = Read(id, false);
+            ctx.Projects.Remove(ConvertToDTO(toDelete));
             ctx.SaveChanges();
         }
         
         public IEnumerable<Project> ReadAll()
         {
-            IEnumerable<Project> myQuery = new List<Project>();
+            List<Project> myQuery = new List<Project>();
 
             foreach(ProjectsDTO DTO in ctx.Projects)
             {
-                myQuery.Append(ConvertToDomain(DTO));
+                myQuery.Add(ConvertToDomain(DTO));
             }
 
             return myQuery;
@@ -221,24 +223,26 @@ namespace DAL
         public void Update(Phase obj)
         {
             PhasesDTO newPhase = ConvertToDTO(obj);
-            PhasesDTO foundPhase = ConvertToDTO(ReadPhase(obj.Project.Id, obj.Id, false));
+            Phase found = ReadPhase(obj.Project.Id, obj.Id, false);
+            PhasesDTO foundPhase = ConvertToDTO(found);
             foundPhase = newPhase;
             ctx.SaveChanges();
         }
 
         public void Delete(int projectID, int phaseID)
         {
-            ctx.Phases.Remove(ConvertToDTO(ReadPhase(projectID,phaseID, false)));
+            Phase toDelete = ReadPhase(projectID, phaseID, false);
+            ctx.Phases.Remove(ConvertToDTO(toDelete));
             ctx.SaveChanges();
         }
 
         public IEnumerable<Phase> ReadAllPhases(int projectID)
         {
-            IEnumerable<Phase> myQuery = new List<Phase>();
+            List<Phase> myQuery = new List<Phase>();
 
             foreach (PhasesDTO DTO in ctx.Phases)
             {
-                myQuery.Append(ConvertToDomain(DTO));
+                myQuery.Add(ConvertToDomain(DTO));
             }
 
             return myQuery;

--- a/DAL/repos/QuestionnaireQuestionsRepository.cs
+++ b/DAL/repos/QuestionnaireQuestionsRepository.cs
@@ -169,7 +169,8 @@ namespace DAL
         public void Update(QuestionnaireQuestion obj)
         {
             QuestionnaireQuestionsDTO newQuestionnaireQuestion = ConvertToDTO(obj);
-            QuestionnaireQuestionsDTO foundQuestionnaireQuestion = ConvertToDTO(Read(obj.Id, false));
+            QuestionnaireQuestion found = Read(obj.Id, false);
+            QuestionnaireQuestionsDTO foundQuestionnaireQuestion = ConvertToDTO(found);
             foundQuestionnaireQuestion = newQuestionnaireQuestion;
 
             ctx.SaveChanges();
@@ -177,17 +178,18 @@ namespace DAL
 
         public void Delete(int id)
         {
-            ctx.QuestionnaireQuestions.Remove(ConvertToDTO(Read(id, false)));
+            QuestionnaireQuestion toDelete = Read(id, false);
+            ctx.QuestionnaireQuestions.Remove(ConvertToDTO(toDelete));
             ctx.SaveChanges();
         }
         
         public IEnumerable<QuestionnaireQuestion> ReadAll()
         {
-            IEnumerable<QuestionnaireQuestion> myQuery = new List<QuestionnaireQuestion>();
+            List<QuestionnaireQuestion> myQuery = new List<QuestionnaireQuestion>();
 
             foreach (QuestionnaireQuestionsDTO DTO in ctx.QuestionnaireQuestions)
             {
-                myQuery.Append(ConvertToDomain(DTO));
+                myQuery.Add(ConvertToDomain(DTO));
             }
 
             return myQuery;
@@ -219,7 +221,8 @@ namespace DAL
                 ctx.Answers.Add(MultipleConvertToDTO(ma));
                 foreach(String s in ma.Choices)
                 {
-                    ctx.Choices.Add(ConvertToDTO(ReadOptionID(s,ma.Question.Id),ma.Id,ctx.Choices.Count()+1));
+                    int id = ReadOptionID(s, ma.Question.Id);
+                    ctx.Choices.Add(ConvertToDTO(id,ma.Id,ctx.Choices.Count()+1));
                 }
             }
             ctx.SaveChanges();
@@ -288,17 +291,18 @@ namespace DAL
 
         public IEnumerable<Answer> ReadAll(int questionID)
         {
-            IEnumerable<Answer> myQuery = new List<Answer>();
+            List<Answer> myQuery = new List<Answer>();
 
             foreach (AnswersDTO DTO in ctx.Answers.ToList().FindAll(a => a.QQuestionID == questionID))
             {
                 if (ctx.Choices.Where(c => c.AnswerID == DTO.AnswerID).Count() == 0)
                 {
-                    myQuery.Append(ConvertToDomain(DTO));
+                    myQuery.Add(ConvertToDomain(DTO));
                 }
                 else
                 {
-                    myQuery.Append(ReadMultipleAnswer(DTO.AnswerID, false));
+                    MultipleAnswer toAdd = ReadMultipleAnswer(DTO.AnswerID, false);
+                    myQuery.Add(toAdd);
                 }
             }
 
@@ -350,13 +354,14 @@ namespace DAL
 
         public void DeleteOption(int optionID, int questionID)
         {
-            ctx.Options.Remove(ConvertToDTO(optionID, ReadOption(optionID, questionID), questionID));
+            string toDelete = ReadOption(optionID, questionID);
+            ctx.Options.Remove(ConvertToDTO(optionID, toDelete, questionID));
             ctx.SaveChanges();
         }
         
         public IEnumerable<string> ReadAllOptions(int QuestionID)
         {
-            IEnumerable<string> myQuery = new List<string>();
+            List<string> myQuery = new List<string>();
 
             foreach (OptionsDTO DTO in ctx.Options)
             {

--- a/DAL/repos/QuestionnaireRepository.cs
+++ b/DAL/repos/QuestionnaireRepository.cs
@@ -105,7 +105,8 @@ namespace DAL
         public void Update(Questionnaire obj)
         {
             ModulesDTO newModule = ConvertToDTO(obj);
-            ModulesDTO foundModule = ConvertToDTO(Read(obj.Id,false));
+            Questionnaire found = Read(obj.Id, false);
+            ModulesDTO foundModule = ConvertToDTO(found);
             foundModule = newModule;
 
             ctx.SaveChanges();
@@ -113,13 +114,14 @@ namespace DAL
 
         public void Delete(int id)
         {
-            ctx.Modules.Remove(ConvertToDTO(Read(id, false)));
+            Questionnaire toDelete = Read(id, false);
+            ctx.Modules.Remove(ConvertToDTO(toDelete));
             ctx.SaveChanges();
         }
         
         public IEnumerable<Questionnaire> ReadAll()
         {
-            IEnumerable<Questionnaire> myQuery = new List<Questionnaire>();
+            List<Questionnaire> myQuery = new List<Questionnaire>();
 
             foreach (ModulesDTO DTO in ctx.Modules)
             {
@@ -136,10 +138,12 @@ namespace DAL
         #endregion   
 
         // Added by NVZ
+        // Tag CRUD
         #region
         public string CreateTag(string obj, int moduleID)
         {
-            ModulesDTO module = ConvertToDTO(Read(moduleID, false));
+            Questionnaire moduleWTags = Read(moduleID, false);
+            ModulesDTO module = ConvertToDTO(moduleWTags);
             module.Tags += "," + obj;
             ctx.SaveChanges();
 
@@ -149,7 +153,8 @@ namespace DAL
         public void DeleteTag(int moduleID, int tagID)
         {
             List<String> keptTags = new List<string>();
-            ModulesDTO module = ConvertToDTO(Read(moduleID, false));
+            Questionnaire moduleWTags = Read(moduleID, false);
+            ModulesDTO module = ConvertToDTO(moduleWTags);
             keptTags = ExtensionMethods.StringToList(module.Tags);
             keptTags.RemoveAt(tagID - 1);
             module.Tags = ExtensionMethods.ListToString(keptTags);

--- a/DAL/repos/UserRepository.cs
+++ b/DAL/repos/UserRepository.cs
@@ -200,11 +200,13 @@ namespace DAL
         public void Update(User obj)
         {
             UsersDTO newUser = ConvertToDTO(obj);
-            UsersDTO foundUser = ConvertToDTO(Read(obj.Id, false));
+            User found = Read(obj.Id, false);
+            UsersDTO foundUser = ConvertToDTO(found);
             foundUser = newUser;
 
             UserDetailsDTO newDetails = RetrieveDetailsFromUser(obj);
-            UserDetailsDTO foundDetails = RetrieveDetailsFromUser(ReadWithDetails(obj.Id));
+            User foundWDetails = ReadWithDetails(obj.Id);
+            UserDetailsDTO foundDetails = RetrieveDetailsFromUser(foundWDetails);
             foundDetails = newDetails;
 
             ctx.SaveChanges();
@@ -212,18 +214,21 @@ namespace DAL
         
         public void Delete(int id)
         {
-            ctx.Users.Remove(ConvertToDTO(Read(id, false)));
-            ctx.UserDetails.Remove(RetrieveDetailsFromUser(Read(id, false)));
+            User toDelete = Read(id, false);
+            ctx.Users.Remove(ConvertToDTO(toDelete));
+            User toDeleteDetails = Read(id, false);
+            ctx.UserDetails.Remove(RetrieveDetailsFromUser(toDeleteDetails));
             ctx.SaveChanges();
         }
         
         public IEnumerable<User> ReadAll()
         {
-            IEnumerable<User> myQuery = new List<User>();
+            List<User> myQuery = new List<User>();
 
             foreach (UsersDTO DTO in ctx.Users)
-            {              
-                myQuery.Append(ReadWithDetails(DTO.UserID));
+            {
+                User toAdd = ReadWithDetails(DTO.UserID);
+                myQuery.Add(toAdd);
             }
 
             return myQuery;
@@ -231,13 +236,14 @@ namespace DAL
 
         public IEnumerable<Organisation> ReadAllOrganisations()
         {
-            IEnumerable<Organisation> myQuery = new List<Organisation>();
+            List<Organisation> myQuery = new List<Organisation>();
 
             foreach (UsersDTO DTO in ctx.Users)
             {
                 if(DTO.Role == 3)
                 {
-                    myQuery.Append(ReadWithDetails(DTO.UserID));
+                    Organisation user = (Organisation) ReadWithDetails(DTO.UserID);
+                    myQuery.Add(user);
                 } 
             }
 


### PR DESCRIPTION
Net zoals in IdeationQuestionRepository ik heb gedaan voor het te fixen dankzij Sacha heb ik het ineens doorgevoerd voor alle Repositories.

In Short
- Alle CRUD operaties niet meer meegegeven als parameter van een methode (Zorgt er blijkbaar voor dat em de read achterhoud ofzo, ik stupid right)
- Append --> Add voor Sacha zijn autisme

![selfdeprecatingjoke](https://media.tenor.com/images/322aa4c0b456bf7a054a760345d8ad03/tenor.gif)

Code knight out

![knight](https://media.tenor.com/images/8cbdd0bcd24546a0d0fb80f7f8d710aa/tenor.gif)